### PR TITLE
Made TaskSetFragment's FAB icon white

### DIFF
--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#ffffffff"
         android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
 </vector>


### PR DESCRIPTION
Made the `FloatingActionButton` icon for `TaskSetFragment` white. 

Closes #14