### PR TITLE
bug/#12 handle absence of managed file

### DIFF
--- a/app/src/main/java/nl/tue/san/tasks/TaskSetManager.java
+++ b/app/src/main/java/nl/tue/san/tasks/TaskSetManager.java
@@ -161,6 +161,11 @@ public class TaskSetManager extends Manager<LinkedHashMap<String, TaskSet>> {
         return map;
     }
 
+    @Override
+    protected LinkedHashMap<String, TaskSet> initialObject() {
+        return new LinkedHashMap<>();
+    }
+
     /**
      * Register the given TaskSet under this manager.
      *

--- a/app/src/main/java/nl/tue/san/util/Manager.java
+++ b/app/src/main/java/nl/tue/san/util/Manager.java
@@ -32,12 +32,29 @@ public abstract class Manager<T>  {
     protected Manager(File file){
         this();
         this.setFile(file);
+
         try {
             this.reload();
         } catch (Exception e) {
-            Log.d(this.getClass().getName(),"Couldn't load visualization from file "+this.file.getAbsolutePath()+
-                    " due to "+e.getClass().getSimpleName()+":  "+e.getMessage()+"." +
-                    " Call reload on "+this.getClass().getName()+" to get full exception.");
+
+            this.managed = initialObject();
+            try {
+                this.write();
+
+                Log.d(this.getClass().getName(),"Couldn't load visualization from file "+this.file.getAbsolutePath()+" due to exception: ");
+                e.printStackTrace();
+                Log.d(this.getClass().getName(),"Using initial object instead");
+
+            } catch (Exception e1) {
+                Log.d(this.getClass().getName(), "Failed to write initial object to file after already failing to load. ");
+                Log.d(this.getClass().getName(), "Exception that occurred when we tried to reload:");
+                e.printStackTrace();
+                Log.d(this.getClass().getName(), "Exception that occurred when we tried to write the initial object:");
+                e1.printStackTrace();
+
+                throw new RuntimeException(e1);
+            }
+
         }
 
     }

--- a/app/src/main/java/nl/tue/san/util/Manager.java
+++ b/app/src/main/java/nl/tue/san/util/Manager.java
@@ -78,20 +78,32 @@ public abstract class Manager<T>  {
     protected abstract T initialObject();
 
     /**
-     * Asserts that access has been given to the required directory. If access was not given, an
-     * {@link IllegalStateException} is thrown. If the assertion is met, the method terminates
-     * normally.
+     * Asserts that the file to which we want to write is set, and thus we have write access. If
+     * access was not given, an {@link IllegalStateException} is thrown. If the assertion is met,
+     * the method terminates normally.
+     * @throws IllegalStateException If the assertion is not met
      */
-    private void assertAccess(){
-        if(file == null)
+    private void assertWriteAccess(){
+        if(file == null )
             throw new IllegalStateException("Can't access file to write to");
     }
 
+
+    /**
+     * Asserts that the file from which we want to read exists, and thus we have read access. If
+     * access was not given, an {@link IllegalStateException} is thrown. If the assertion is met,
+     * the method terminates normally.
+     * @throws IllegalStateException If the assertion is not met
+     */
+    private void assertReadAccess(){
+        if(file == null || !file.exists())
+            throw new IllegalStateException("Can't access file to write to");
+    }
     /**
      * Perform a reload of all TaskSets.
      */
     public void reload() throws Exception{
-        assertAccess();
+        assertReadAccess();
 
         // Convert the root file into a String
         StringBuilder builder = new StringBuilder();
@@ -162,7 +174,7 @@ public abstract class Manager<T>  {
      * Write all TaskSets. This provides synchronization.
      */
     public void write() throws Exception{
-        assertAccess();
+        assertWriteAccess();
 
         try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(this.file)))) {
             writer.write(this.writeAsReturn());

--- a/app/src/main/java/nl/tue/san/util/Manager.java
+++ b/app/src/main/java/nl/tue/san/util/Manager.java
@@ -75,6 +75,8 @@ public abstract class Manager<T>  {
      */
     protected abstract T unmarshall(String content) throws Exception;
 
+    protected abstract T initialObject();
+
     /**
      * Asserts that access has been given to the required directory. If access was not given, an
      * {@link IllegalStateException} is thrown. If the assertion is met, the method terminates

--- a/app/src/main/java/nl/tue/san/visualization/VisualizationManager.java
+++ b/app/src/main/java/nl/tue/san/visualization/VisualizationManager.java
@@ -208,6 +208,11 @@ public class VisualizationManager extends Manager<Visualization> {
         return VisualizationIO.fromJSON(new JSONObject(new JSONTokener(content)));
     }
 
+    @Override
+    protected Visualization initialObject() {
+        return new Visualization();
+    }
+
     public long getEndOfRecentIdentification() {
         return endOfRecentIdentification;
     }


### PR DESCRIPTION
Handle the case of the storage of a managed object not existing. This makes `Manager`s more robust. Additionally, as a result of this pull request, `Manager`s will now work in case of a corrupted file or a completely absent file. 

Closes #12