### PR TITLE
Define absolute threshold on IO operations

### DIFF
--- a/app/src/main/java/nl/tue/san/tasks/TaskIO.java
+++ b/app/src/main/java/nl/tue/san/tasks/TaskIO.java
@@ -120,15 +120,75 @@ public class TaskIO {
      * @throws JSONException If writing to the JSONObject failed.
      */
     public static JSONObject toJSON(Task task) throws JSONException {
+        return  TaskIO.toJSON(task, true);
+    }
+
+    /**
+     * Converts a Task to a JSONObject. The returned JSONObject contains the following properties,
+     * in no particular order:
+     * <ul>
+     *      <li>
+     *          <strong>Name</strong>
+     *          <em>(String)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Priority</strong>
+     *          <em>(Integer >= 0)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Threshold</strong>
+     *          <em>(Integer >= 0, indicates the priority threshold for interruptions in case of FPTS)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Computation</strong>
+     *          <em>(Integer > 0, the computation time required for each job)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Period</strong>
+     *          <em>(Integer > 0, indicates how much time exists between two job instances of the task)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Deadline</strong>
+     *          <em>(Integer > 0, indicates how much time a job instance has to complete)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Offset</strong>
+     *          <em>(Integer >= 0, indicates the offset in the arrival of the first job of this task, opposed to the global starting time)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Color</strong>
+     *          <em>(Color (#RRGGBB), the color to use to represent this task)</em>
+     *      </li>
+     * </ul>
+     * @param task The Task to convert to JSON
+     * @param allowThresholdFlags Whether the threshold should be absolute
+     *                            ({@code false}) or whether flag values are also allowed
+     *                            ({@code true}).
+     * @return A JSONObject representing the given Task.
+     * @throws JSONException If writing to the JSONObject failed.
+     */
+    public static JSONObject toJSON(Task task, boolean allowThresholdFlags) throws JSONException {
         return new JSONObject()
                 .put(NAME, task.getName())
                 .put(PRIORITY,task.getPriority())
-                .put(THRESHOLD,task.getThreshold())
+                .put(THRESHOLD,allowThresholdFlags ? task.getThreshold() : absoluteThreshold(task))
                 .put(COMPUTATION,task.getComputation())
                 .put(PERIOD,task.getPeriod())
                 .put(DEADLINE,task.getDeadline())
                 .put(OFFSET,task.getOffset())
                 .put(COLOR,'#'+task.getHexColor());
+    }
+
+    /**
+     * Get the absolute threshold for the given task
+     * @param task The Task from which to obtain the absolute value
+     * @return The absolute threshold value.
+     */
+    private static int absoluteThreshold(Task task) {
+        if(task.getThreshold() == Task.NO_PREEMPTION_THRESHOLD)
+            return task.getPriority() + 1;
+        else
+            return task.getThreshold();
     }
 
     private static final String NAME = "Name";

--- a/app/src/main/java/nl/tue/san/tasks/TaskSetIO.java
+++ b/app/src/main/java/nl/tue/san/tasks/TaskSetIO.java
@@ -93,10 +93,35 @@ public class TaskSetIO {
      * @throws JSONException If writing to the JSONObject failed.
      */
     public static JSONObject toJSON(TaskSet taskSet) throws JSONException {
+        return TaskSetIO.toJSON(taskSet, true);
+    }
+
+    /**
+     * Converts a TaskSet to a JSONObject. The returned JSONObject contains the following properties,
+     * in no particular order:
+     * <ul>
+     *      <li>
+     *          <strong>Name</strong>
+     *          <em>(String)</em>
+     *      </li>
+     *      <li>
+     *          <strong>Tasks</strong>
+     *          <em>(Array. The items in the array are match the requirements set by
+     *          {@link TaskIO#toJSON(Task)} )</em>
+     *      </li>
+     * </ul>
+     * @param taskSet The TaskSet to convert to JSON
+     * @param allowThresholdFlags Whether the threshold should be absolute
+     *                            ({@code false}) or whether flag values are also allowed
+     *                            ({@code true}).
+     * @return A JSONObject representing the given TaskSet.
+     * @throws JSONException If writing to the JSONObject failed.
+     */
+    public static JSONObject toJSON(TaskSet taskSet, boolean allowThresholdFlags) throws JSONException {
 
         JSONArray tasks = new JSONArray();
         for(Task task : taskSet.getOrderedTasks())
-            tasks.put(TaskIO.toJSON(task));
+            tasks.put(TaskIO.toJSON(task, allowThresholdFlags));
 
         return new JSONObject()
                 .put(TASKS,tasks)
@@ -104,6 +129,5 @@ public class TaskSetIO {
                 ;
 
     }
-
 
 }

--- a/app/src/main/java/nl/tue/san/ui/HomeFragment.java
+++ b/app/src/main/java/nl/tue/san/ui/HomeFragment.java
@@ -168,7 +168,7 @@ public class HomeFragment extends ProgressableFragment implements Navigatable {
 
             try {
                 this.showProgress(0, steps);
-                final String taskSet = TaskSetIO.toJSON(this.taskSetManager.get((String) this.taskSet.getSelectedItem())).toString();
+                final String taskSet = TaskSetIO.toJSON(this.taskSetManager.get((String) this.taskSet.getSelectedItem()), false).toString();
                 this.showProgress(1, steps);
                 final String visualization = VisualizationIO.toJSON(this.manager.getVisualization()).toString();
                 this.showProgress(2, steps);


### PR DESCRIPTION
Send tasksets with absolute thresholds. Flag thresholds, like `NO_PREEMPTION_THRESHOLD`, are converted into an absolute value.

Closes #34 