### PR TITLE
Rename Animation duration

### DIFF
--- a/app/src/main/res/layout/fragment_visualization.xml
+++ b/app/src/main/res/layout/fragment_visualization.xml
@@ -103,7 +103,7 @@
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:text="Animation duration"/>
+                android:text="Schedule length"/>
 
             <RelativeLayout
                 android:layout_width="0dp"
@@ -115,6 +115,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
+                    android:visibility="invisible"
                     android:text="ms"/>
 
                 <EditText


### PR DESCRIPTION
Renamed "animation duration" to "schedule length". The unit is also removed.

Closes #39 